### PR TITLE
Support wider range of remote urls with Local provider

### DIFF
--- a/packages/client/src/ci-providers/Local.ts
+++ b/packages/client/src/ci-providers/Local.ts
@@ -3,8 +3,6 @@ import * as execa from "execa";
 import { PrInfo } from "../api";
 import { CodeChecksReport } from "../types";
 
-const REMOTE_URL_REGEXP = /^git\@github\.com\:(.*)\.git$/;
-
 /**
  * Run codechecks locally, not on CI. It requires running within git reposistory.
  */
@@ -29,13 +27,7 @@ export class LocalProvider implements CiProvider {
 
     const rawRemoteUrl = (await execa.shell("git config --get remote.origin.url")).stdout.trim();
 
-    const matches = REMOTE_URL_REGEXP.exec(rawRemoteUrl);
-    if (!matches || !matches[1]) {
-      throw new Error(`Can't get project slug from ${rawRemoteUrl}`);
-    }
-    const projectSlug = matches[1];
-
-    return projectSlug;
+    return fullNameFromRemoteUrl(rawRemoteUrl);
   }
 
   getPullRequestID(): number {
@@ -86,6 +78,7 @@ import * as marked from "marked";
 import * as TerminalRenderer from "marked-terminal";
 import { logger } from "../logger";
 import chalk from "chalk";
+import { fullNameFromRemoteUrl } from "../utils/git";
 
 marked.setOptions({
   // Define custom renderer
@@ -95,14 +88,14 @@ marked.setOptions({
 export function printCheck(report: CodeChecksReport): void {
   console.log(
     marked(`
-# ${report.status === "success" ? "✅" : "❌"} ${report.name} 
+# ${report.status === "success" ? "✅" : "❌"} ${report.name}
 ${report.shortDescription}`),
   );
 
   if (report.longDescription) {
     console.log(
       marked(`
-## Long description: 
+## Long description:
 ${report.longDescription}`),
     );
   }

--- a/packages/client/src/utils/__tests__/git.test.ts
+++ b/packages/client/src/utils/__tests__/git.test.ts
@@ -1,41 +1,65 @@
 import * as mockFS from "mock-fs";
 import { join } from "path";
-import { findRootGitRepository } from "../git";
+import { findRootGitRepository, fullNameFromRemoteUrl } from "../git";
 
 const rootVirtualPath = "/app";
 
 describe("utils > git", () => {
-  it("should find root project directory", () => {
-    mockFS({
-      [join(rootVirtualPath)]: {
-        ".git": {
-          "internal-git-files": "",
+  describe("findRootGitRepository", () => {
+    it("should find root project directory", () => {
+      mockFS({
+        [join(rootVirtualPath)]: {
+          ".git": {
+            "internal-git-files": "",
+          },
         },
-      },
+      });
+
+      const actualRootGitRepo = findRootGitRepository(rootVirtualPath);
+
+      mockFS.restore();
+      expect(actualRootGitRepo).toBe(rootVirtualPath);
     });
 
-    const actualRootGitRepo = findRootGitRepository(rootVirtualPath);
+    it("should find root project directory from subdirectory", () => {
+      mockFS({
+        [rootVirtualPath]: {
+          ".git": {
+            "internal-git-files": "",
+          },
+          src: {
+            "index.js": "",
+          },
+        },
+      });
 
-    mockFS.restore();
-    expect(actualRootGitRepo).toBe(rootVirtualPath);
+      const path = join(rootVirtualPath, "src");
+      const actualRootGitRepo = findRootGitRepository(path);
+
+      mockFS.restore();
+      expect(actualRootGitRepo).toBe(rootVirtualPath);
+    });
   });
 
-  it("should find root project directory from subdirectory", () => {
-    mockFS({
-      [rootVirtualPath]: {
-        ".git": {
-          "internal-git-files": "",
-        },
-        src: {
-          "index.js": "",
-        },
-      },
+  describe("fullNameFromRemoteUrl", () => {
+    it("should returns repository full name from ssh url", () => {
+      expect(fullNameFromRemoteUrl("git@github.com:codechecks/monorepo.git")).toEqual("codechecks/monorepo");
+      expect(fullNameFromRemoteUrl("git@github.com:codechecks/awesome-codechecks.git")).toEqual("codechecks/awesome-codechecks");
+      expect(fullNameFromRemoteUrl("git@github.com:MikeMcl/bignumber.js.git")).toEqual("MikeMcl/bignumber.js");
     });
 
-    const path = join(rootVirtualPath, "src");
-    const actualRootGitRepo = findRootGitRepository(path);
+    it("should returns repository full name from clone url", () => {
+      expect(fullNameFromRemoteUrl("https://github.com/codechecks/monorepo.git")).toEqual("codechecks/monorepo");
+      expect(fullNameFromRemoteUrl("http://github.com/codechecks/monorepo.git")).toEqual("codechecks/monorepo");
+    });
 
-    mockFS.restore();
-    expect(actualRootGitRepo).toBe(rootVirtualPath);
+    it("should returns repository full name from svn url", () => {
+      expect(fullNameFromRemoteUrl("https://github.com/codechecks/monorepo")).toEqual("codechecks/monorepo");
+      expect(fullNameFromRemoteUrl("http://github.com/codechecks/monorepo")).toEqual("codechecks/monorepo");
+    });
+
+    it("should throw on unmatched url", () => {
+      expect(() => fullNameFromRemoteUrl("github.com/codechecks/monorepo")).toThrowError("Can't get project slug from github.com/codechecks/monorepo")
+    });
   });
 });

--- a/packages/client/src/utils/__tests__/git.test.ts
+++ b/packages/client/src/utils/__tests__/git.test.ts
@@ -42,18 +42,18 @@ describe("utils > git", () => {
   });
 
   describe("fullNameFromRemoteUrl", () => {
-    it("should returns repository full name from ssh url", () => {
+    it("should return repository full name from ssh url", () => {
       expect(fullNameFromRemoteUrl("git@github.com:codechecks/monorepo.git")).toEqual("codechecks/monorepo");
       expect(fullNameFromRemoteUrl("git@github.com:codechecks/awesome-codechecks.git")).toEqual("codechecks/awesome-codechecks");
       expect(fullNameFromRemoteUrl("git@github.com:MikeMcl/bignumber.js.git")).toEqual("MikeMcl/bignumber.js");
     });
 
-    it("should returns repository full name from clone url", () => {
+    it("should return repository full name from clone url", () => {
       expect(fullNameFromRemoteUrl("https://github.com/codechecks/monorepo.git")).toEqual("codechecks/monorepo");
       expect(fullNameFromRemoteUrl("http://github.com/codechecks/monorepo.git")).toEqual("codechecks/monorepo");
     });
 
-    it("should returns repository full name from svn url", () => {
+    it("should return repository full name from svn url", () => {
       expect(fullNameFromRemoteUrl("https://github.com/codechecks/monorepo")).toEqual("codechecks/monorepo");
       expect(fullNameFromRemoteUrl("http://github.com/codechecks/monorepo")).toEqual("codechecks/monorepo");
     });

--- a/packages/client/src/utils/__tests__/git.test.ts
+++ b/packages/client/src/utils/__tests__/git.test.ts
@@ -44,7 +44,9 @@ describe("utils > git", () => {
   describe("fullNameFromRemoteUrl", () => {
     it("should return repository full name from ssh url", () => {
       expect(fullNameFromRemoteUrl("git@github.com:codechecks/monorepo.git")).toEqual("codechecks/monorepo");
-      expect(fullNameFromRemoteUrl("git@github.com:codechecks/awesome-codechecks.git")).toEqual("codechecks/awesome-codechecks");
+      expect(fullNameFromRemoteUrl("git@github.com:codechecks/awesome-codechecks.git")).toEqual(
+        "codechecks/awesome-codechecks",
+      );
       expect(fullNameFromRemoteUrl("git@github.com:MikeMcl/bignumber.js.git")).toEqual("MikeMcl/bignumber.js");
     });
 
@@ -59,7 +61,9 @@ describe("utils > git", () => {
     });
 
     it("should throw on unmatched url", () => {
-      expect(() => fullNameFromRemoteUrl("github.com/codechecks/monorepo")).toThrowError("Can't get project slug from github.com/codechecks/monorepo")
+      expect(() => fullNameFromRemoteUrl("github.com/codechecks/monorepo")).toThrowError(
+        "Can't get project slug from github.com/codechecks/monorepo",
+      );
     });
   });
 });

--- a/packages/client/src/utils/git.ts
+++ b/packages/client/src/utils/git.ts
@@ -1,6 +1,8 @@
 import { existsSync } from "fs";
 import { join } from "path";
 
+const REMOTE_URL_REGEXP = /^(?:(?:git\@)|(?:https?:\/\/))github\.com(?::|\/)(.+)$/;
+
 export function findRootGitRepository(path: string): string | undefined {
   const gitDirPath = join(path, ".git");
   const parentDir = join(path, "..");
@@ -14,4 +16,12 @@ export function findRootGitRepository(path: string): string | undefined {
   } else {
     return findRootGitRepository(parentDir);
   }
+}
+
+export function fullNameFromRemoteUrl(remoteUrl: string): string {
+  const matches = remoteUrl.match(REMOTE_URL_REGEXP);
+  if (!matches || !matches[1]) {
+    throw new Error(`Can't get project slug from ${remoteUrl}`);
+  }
+  return matches[1].replace(/(.git)$/, "");
 }


### PR DESCRIPTION
This PR fixes #23 

`fullNameFromRemoteUrl` shouldn't be used as a validation function as it tries to optimistically match all may-be-valid URLs and would allow mixing of segments that might not be a valid remote. For maximum compliance, something like https://github.com/IonicaBizau/git-url-parse can be considered.

Also, `.git` in repo name gets special treatment (at least from github):

* `some.js` is `some.js`
* `some.git` is `some`
* `some.js.git` is `some.js`