### PR TITLE
 Implement fail fast mode for local execution

### DIFF
--- a/packages/client/src/ci-providers/__tests__/Local.test.ts
+++ b/packages/client/src/ci-providers/__tests__/Local.test.ts
@@ -1,0 +1,60 @@
+import { processReport } from "../Local";
+import { CodeChecksReport } from "client/src/types";
+import { ExecutionContext } from "client/src/getExecutionContext";
+import { logger } from "../../logger";
+import { fixtureFactory } from "./utils";
+
+const reportFixture = fixtureFactory<CodeChecksReport>({
+  name: "Build Size",
+  shortDescription: "[...]",
+  longDescription: "[...]",
+  status: "success",
+});
+
+const contextFixture = fixtureFactory<ExecutionContext>({
+  codeChecksFileAbsPath: "/codechecks.yml",
+  workspaceRoot: "/",
+  isPr: true,
+  isPrivate: false,
+  projectSlug: "codechecks/monorepo",
+  artifactsProxy: { url: "https://artifacts.codechecks.io/", supportsPages: true },
+  currentSha: "5fe201cd36d2878b8a34f717207c94f9724aef45",
+  isLocalMode: { projectSlug: "codechecks/monorepo", isOffline: false, isFailFast: false },
+  pr: {
+    id: 0,
+    meta: { title: "Local run", body: "local run" },
+    files: { added: [], changed: [], removed: [] },
+    head: { sha: "5fe201cd36d2878b8a34f717207c94f9724aef45" },
+    base: { sha: "c7bb7435e90418edb032e61eadbd89bfcb5d01c1" },
+  },
+  isFork: false,
+  isSpeculativePr: false,
+});
+
+jest.mock("../../logger.ts");
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("Local", () => {
+  describe("processReport", () => {
+    it("doesn't log critical error for successful report", () => {
+      processReport(reportFixture({ status: "success" }), contextFixture());
+      expect(logger.critical).not.toHaveBeenCalled();
+    });
+
+    it("doesn't log critical error for failed report without fail fast mode", () => {
+      processReport(reportFixture({ status: "failure" }), contextFixture());
+      expect(logger.critical).not.toHaveBeenCalled();
+    });
+
+    it("logs critical error for failed report in fail fast mode", () => {
+      const context = contextFixture({
+        isLocalMode: { projectSlug: "codechecks/monorepo", isOffline: false, isFailFast: true },
+      });
+      processReport(reportFixture({ status: "failure" }), context);
+      expect(logger.critical).toHaveBeenCalledWith('"Build Size" check failed in fail fast mode');
+    });
+  });
+});

--- a/packages/client/src/ci-providers/__tests__/utils.ts
+++ b/packages/client/src/ci-providers/__tests__/utils.ts
@@ -7,3 +7,7 @@ export function readEnvFile(path: string): Env {
   const envFile = readFileSync(path, "utf8");
   return dotenv.parse(envFile);
 }
+
+export function fixtureFactory<T>(defaults: T): (params?: Partial<T>) => T {
+  return (params = {}) => ({ ...defaults, ...params });
+}

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -2,7 +2,7 @@ import { Api } from "./api";
 import { ExecutionContext } from "./getExecutionContext";
 import { CodeChecksReport, CodeChecksReportBody } from "./types";
 import { join } from "path";
-import { printCheck } from "./ci-providers/Local";
+import { processReport } from "./ci-providers/Local";
 const urlJoin = require("url-join") as (...args: string[]) => string;
 
 export class NotPrError extends Error {
@@ -68,7 +68,7 @@ export class CodechecksClient {
 
   public async report(report: CodeChecksReport): Promise<void> {
     if (this.context.isLocalMode) {
-      return printCheck(report);
+      return processReport(report, this.context);
     } else {
       return this.api.makeCommitCheck(
         this.context.currentSha,

--- a/packages/client/src/file-executors/executeJson.ts
+++ b/packages/client/src/file-executors/executeJson.ts
@@ -54,7 +54,7 @@ export const standardNameMapper = (path: string) => (checkName: string): string 
     return join(dirname(path), checkName);
   }
 
-  throw new Error(`Module ${checkName} couldn't be found. Tried: 
+  throw new Error(`Module ${checkName} couldn't be found. Tried:
 - @codechecks/${checkName}
 - ${checkName}
 `);
@@ -64,7 +64,7 @@ function checkIfModuleExists(moduleName: string): boolean {
   try {
     require.resolve(moduleName);
     return true;
-  } catch (e) {
+  } catch {
     return false;
   }
 }

--- a/packages/client/src/getExecutionContext.ts
+++ b/packages/client/src/getExecutionContext.ts
@@ -4,7 +4,7 @@ import { DeepReadonly } from "ts-essentials";
 import { Path } from "./utils";
 import { dirname } from "path";
 import { LocalProvider } from "./ci-providers/Local";
-import { CodeChecksSettings } from "./types";
+import { CodeChecksSettings, CodeChecksClientArgs } from "./types";
 import { getPrInfoForSpeculativeBranch } from "./speculativeBranchSelection";
 
 /**
@@ -15,6 +15,7 @@ export async function getConstExecutionContext(
   ciProvider: CiProvider,
   settings: CodeChecksSettings,
   gitRepoRootPath: string,
+  args: CodeChecksClientArgs,
 ): Promise<SharedExecutionContext> {
   const currentSha = await ciProvider.getCurrentSha();
   const isFork = await ciProvider.isFork();
@@ -45,6 +46,7 @@ export async function getConstExecutionContext(
     localMode = {
       projectSlug,
       isOffline,
+      isFailFast: !!args.failFast,
     };
     prInfo = await ciProvider.getPrInfo();
   } else if (isFork) {
@@ -136,6 +138,7 @@ export interface SharedExecutionContext {
   isLocalMode?: {
     projectSlug: string;
     isOffline: boolean;
+    isFailFast: boolean;
   };
   isFork: boolean;
   isSpeculativePr: boolean;

--- a/packages/client/src/logger.ts
+++ b/packages/client/src/logger.ts
@@ -41,6 +41,11 @@ class Logger {
   error(...args: any[]): void {
     console.error(chalk.red("Error occured: "), ...args);
   }
+
+  critical(...args: any[]): void {
+    console.error(chalk.red("Critical error occured: "), ...args);
+    process.exit(1);
+  }
 }
 
 export const logger = new Logger();

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -18,3 +18,8 @@ export interface CodeChecksSettings {
   speculativeBranchSelection: boolean;
   branches: string[];
 }
+
+export interface CodeChecksClientArgs {
+  project?: string;
+  failFast?: boolean;
+}


### PR DESCRIPTION
This intends to fix #22 

I decided to make it opt-in so the default is consistent with what would happen on CI. The `--fail-fast` option is familiar to `ava` and `rspec` users. I know @krzkaczor proposed `--exitOnError ` but I'm not sold on that name 😛 

Usage:

```
npx codecheks --fail-fast
```

I've put fixtures inside the `Local.test.ts` but I would argue they should be closer to root when there's more need to use these objects in tests.