### PR TITLE
Use crash abstraction over throwing errors

### DIFF
--- a/packages/client/src/api.ts
+++ b/packages/client/src/api.ts
@@ -248,7 +248,7 @@ export class Api {
 
     const result = runOrCatchError(() => lstatSync(directoryPath));
     if (result && !result.isDirectory) {
-      throw new Error(`${directoryPath} is not a directory!`);
+      throw crash(`${directoryPath} is not a directory!`);
     }
 
     const allFiles = glob.sync(`${directoryPath}/**/*`, {

--- a/packages/client/src/api.ts
+++ b/packages/client/src/api.ts
@@ -8,6 +8,7 @@ import { StatusCodeError } from "request-promise/errors";
 import { CodeChecksReport, CodeChecksReportStatus } from "./types";
 import { Stream, Readable } from "stream";
 import { Promise as Bluebird, delay } from "bluebird";
+import { crash } from "./utils/errors";
 import { logger } from "./logger";
 
 import request = require("request");

--- a/packages/client/src/ci-providers/BuildKite.ts
+++ b/packages/client/src/ci-providers/BuildKite.ts
@@ -1,4 +1,5 @@
 import { Env, CiProvider } from "./types";
+import { crash } from "../utils/errors";
 
 export function parseRepositorySlug(repoUrl: string): string {
   const GIT_URL_REGEX = /^(https|git)(:\/\/|@)([^\/:]+)[\/:]([^\/:]+)\/(.+).git$/;

--- a/packages/client/src/ci-providers/BuildKite.ts
+++ b/packages/client/src/ci-providers/BuildKite.ts
@@ -5,7 +5,7 @@ export function parseRepositorySlug(repoUrl: string): string {
   const repoMatch = repoUrl.match(GIT_URL_REGEX);
 
   if (!repoMatch) {
-    throw new Error(`Couldnt parse repository slug from ${repoUrl}`);
+    throw crash(`Couldnt parse repository slug from ${repoUrl}`);
   }
   return `${repoMatch[4]}/${repoMatch[5]}`;
 }
@@ -30,7 +30,7 @@ export class BuildKite implements CiProvider {
   getCurrentSha(): string {
     const sha = this.env["BUILDKITE_COMMIT"];
     if (!sha) {
-      throw new Error("Couldnt get target SHA");
+      throw crash("Couldnt get target SHA");
     }
 
     return sha;

--- a/packages/client/src/ci-providers/Circle.ts
+++ b/packages/client/src/ci-providers/Circle.ts
@@ -1,4 +1,5 @@
 import { Env, CiProvider } from "./types";
+import { crash } from "../utils/errors";
 
 export class Circle implements CiProvider {
   constructor(private readonly env: Env) {}

--- a/packages/client/src/ci-providers/Circle.ts
+++ b/packages/client/src/ci-providers/Circle.ts
@@ -24,7 +24,7 @@ export class Circle implements CiProvider {
   getCurrentSha(): string {
     const sha = this.env["CIRCLE_SHA1"];
     if (!sha) {
-      throw new Error("Couldnt get target SHA");
+      throw crash("Couldnt get target SHA");
     }
 
     return sha;
@@ -43,7 +43,7 @@ export class Circle implements CiProvider {
     const projectName = this.env["CIRCLE_PROJECT_REPONAME"];
 
     if (!user || !projectName) {
-      throw new Error("Missing CIRCLE_PROJECT_USERNAME or CIRCLE_PROJECT_REPONAME");
+      throw crash("Missing CIRCLE_PROJECT_USERNAME or CIRCLE_PROJECT_REPONAME");
     }
 
     return `${user}/${projectName}`;

--- a/packages/client/src/ci-providers/Semaphore.ts
+++ b/packages/client/src/ci-providers/Semaphore.ts
@@ -1,4 +1,5 @@
 import { Env, CiProvider } from "./types";
+import { crash } from "../utils/errors";
 
 export class Semaphore implements CiProvider {
   constructor(private readonly env: Env) {}

--- a/packages/client/src/ci-providers/Semaphore.ts
+++ b/packages/client/src/ci-providers/Semaphore.ts
@@ -14,7 +14,7 @@ export class Semaphore implements CiProvider {
   getCurrentSha(): string {
     const sha = this.env["SEMAPHORE_GIT_SHA"];
     if (!sha) {
-      throw new Error("Couldnt get target SHA");
+      throw crash("Couldnt get target SHA");
     }
 
     return sha;
@@ -31,7 +31,7 @@ export class Semaphore implements CiProvider {
   public getProjectSlug(): string {
     const slug = this.env["SEMAPHORE_PROJECT_NAME"];
     if (!slug) {
-      throw new Error("Couldnt get repo slug");
+      throw crash("Couldnt get repo slug");
     }
 
     return `${this.env["SEMAPHORE_PROJECT_NAME"]}/${this.env["SEMAPHORE_GIT_DIR"]}`;

--- a/packages/client/src/ci-providers/Travis.ts
+++ b/packages/client/src/ci-providers/Travis.ts
@@ -1,4 +1,5 @@
 import { Env, CiProvider } from "./types";
+import { crash } from "../utils/errors";
 
 export class Travis implements CiProvider {
   constructor(private readonly env: Env) {}

--- a/packages/client/src/ci-providers/Travis.ts
+++ b/packages/client/src/ci-providers/Travis.ts
@@ -27,7 +27,7 @@ export class Travis implements CiProvider {
     }
 
     if (!sha) {
-      throw new Error("Couldnt get target SHA");
+      throw crash("Couldnt get target SHA");
     }
 
     return sha;
@@ -45,7 +45,7 @@ export class Travis implements CiProvider {
     const slug = this.env["TRAVIS_REPO_SLUG"];
 
     if (!slug) {
-      throw new Error("Missing TRAVIS_REPO_SLUG");
+      throw crash("Missing TRAVIS_REPO_SLUG");
     }
 
     return slug;

--- a/packages/client/src/ci-providers/index.ts
+++ b/packages/client/src/ci-providers/index.ts
@@ -19,10 +19,10 @@ export function findProvider(env: Env, localProject?: string): CiProvider {
 
   const currentlyRunningProviders = providerInstances.filter(p => p.isCurrentlyRunning());
   if (currentlyRunningProviders.length === 0) {
-    throw new Error("Could not find running CI.");
+    throw crash("Could not find running CI.");
   }
   if (currentlyRunningProviders.length > 1) {
-    throw new Error("Found more than 1 running CI o_O");
+    throw crash("Found more than 1 running CI o_O");
   }
   return currentlyRunningProviders[0];
 }

--- a/packages/client/src/ci-providers/index.ts
+++ b/packages/client/src/ci-providers/index.ts
@@ -4,6 +4,7 @@ import { Semaphore } from "./Semaphore";
 import { CiProvider, Env } from "./types";
 import { LocalProvider } from "./Local";
 import { BuildKite } from "./BuildKite";
+import { crash } from "../utils/errors";
 
 const providers: { new (env: Env, localProject?: string): CiProvider }[] = [
   Circle,

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -55,7 +55,7 @@ export class CodechecksClient {
 
   public async getDirectory(name: string, destinationPath: string): Promise<void> {
     if (!this.context.pr) {
-      crash("Not a PR!");
+      throw crash("Not a PR!");
     }
     return this.api.getDirectory(name, destinationPath, this.context.pr.base.sha, this.getPublicProjectSlug());
   }

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -3,6 +3,7 @@ import { ExecutionContext } from "./getExecutionContext";
 import { CodeChecksReport, CodeChecksReportBody } from "./types";
 import { join } from "path";
 import { processReport } from "./ci-providers/Local";
+import { crash } from "./utils/errors";
 const urlJoin = require("url-join") as (...args: string[]) => string;
 
 export class NotPrError extends Error {
@@ -25,7 +26,7 @@ export class CodechecksClient {
 
   public async getValue<T>(name: string): Promise<T | undefined> {
     if (!this.context.pr) {
-      throw new NotPrError();
+      throw crash("Not a PR!");
     }
     return this.api.getValue<T>(name, this.context.pr.base.sha, this.getPublicProjectSlug());
   }
@@ -39,7 +40,7 @@ export class CodechecksClient {
 
   public async getFile(name: string, destinationPath: string): Promise<void> {
     if (!this.context.pr) {
-      throw new NotPrError();
+      throw crash("Not a PR!");
     }
 
     return this.api.getFile(`${this.context.pr.base.sha}/${name}`, destinationPath, this.getPublicProjectSlug());
@@ -54,7 +55,7 @@ export class CodechecksClient {
 
   public async getDirectory(name: string, destinationPath: string): Promise<void> {
     if (!this.context.pr) {
-      throw new NotPrError();
+      crash("Not a PR!");
     }
     return this.api.getDirectory(name, destinationPath, this.context.pr.base.sha, this.getPublicProjectSlug());
   }

--- a/packages/client/src/file-executors/executeJson.ts
+++ b/packages/client/src/file-executors/executeJson.ts
@@ -54,7 +54,7 @@ export const standardNameMapper = (path: string) => (checkName: string): string 
     return join(dirname(path), checkName);
   }
 
-  throw new Error(`Module ${checkName} couldn't be found. Tried:
+  throw crash(`Module ${checkName} couldn't be found. Tried:
 - @codechecks/${checkName}
 - ${checkName}
 `);

--- a/packages/client/src/file-executors/executeJson.ts
+++ b/packages/client/src/file-executors/executeJson.ts
@@ -1,6 +1,7 @@
 import { logger } from "../logger";
 import { join, dirname } from "path";
 import { executeCodechecksFile } from "./execution";
+import { crash } from "../utils/errors";
 
 export async function executeCodechecksJson(
   path: string,

--- a/packages/client/src/file-executors/execution.ts
+++ b/packages/client/src/file-executors/execution.ts
@@ -6,6 +6,7 @@ import { executeTs } from "./tsExecutor";
 import { executeJs } from "./jsExecutor";
 import { executeCodechecksJson } from "./executeJson";
 import { executeCodechecksYaml } from "./executeYaml";
+import { crash } from "../utils/errors";
 
 const CODECHECKS_FILES_NAMES = [
   "codechecks.yml",

--- a/packages/client/src/file-executors/execution.ts
+++ b/packages/client/src/file-executors/execution.ts
@@ -30,7 +30,7 @@ export async function executeCodechecksFile(codeChecksFilePath: string, options?
     case "yaml":
       return await executeCodechecksYaml(codeChecksFilePath);
     default:
-      throw new Error(`Unsupported file extension ${extension}`);
+      throw crash(`Unsupported file extension ${extension}`);
   }
 }
 
@@ -40,7 +40,7 @@ export function findCodechecksFiles(basePath: string): Path[] {
   });
 
   if (existingFiles.length === 0) {
-    throw new Error(`Couldnt find CodeChecks files. Checked path: ${basePath}`);
+    throw crash(`Couldnt find CodeChecks files. Checked path: ${basePath}`);
   }
 
   return existingFiles as any[];

--- a/packages/client/src/file-executors/moduleExecutor.ts
+++ b/packages/client/src/file-executors/moduleExecutor.ts
@@ -1,4 +1,5 @@
 import { isFunction } from "util";
+import { crash } from "../utils/errors";
 
 export async function moduleExecutor(module: any, options: any): Promise<void> {
   const hasDefaultExport = !!module.default;

--- a/packages/client/src/file-executors/moduleExecutor.ts
+++ b/packages/client/src/file-executors/moduleExecutor.ts
@@ -5,10 +5,10 @@ export async function moduleExecutor(module: any, options: any): Promise<void> {
   const hasMainExport = !!module.main;
   const hasDefaultCommonExport = isFunction(module);
   if (!hasDefaultExport && !hasMainExport && !hasDefaultCommonExport) {
-    throw new Error("Your CodeChecks file has to export default export or function named 'main'");
+    throw crash("Your CodeChecks file has to export default export or function named 'main'");
   }
   if ([hasDefaultExport, hasMainExport, hasDefaultCommonExport].filter(x => x === true).length > 1) {
-    throw new Error(
+    throw crash(
       "Your CodeChecks file can't export default export, 'main' function and default commonjs export at the same time!",
     );
   }

--- a/packages/client/src/file-executors/tsExecutor.ts
+++ b/packages/client/src/file-executors/tsExecutor.ts
@@ -36,14 +36,14 @@ export function transpileTypescriptModule(path: string): string {
     source = contents;
   } else {
     if (!hasTypescript) {
-      throw new Error("File written in TS but typescript package is not installed.");
+      throw crash("File written in TS but typescript package is not installed.");
     }
 
     source = transpileTypescript(contents);
   }
 
   if (!source) {
-    throw new Error(`Couldnt parse ${path}`);
+    throw crash(`Couldnt parse ${path}`);
   }
 
   return source;

--- a/packages/client/src/file-executors/tsExecutor.ts
+++ b/packages/client/src/file-executors/tsExecutor.ts
@@ -4,6 +4,7 @@ import * as JSON5 from "json5";
 
 import { moduleExecutor } from "./moduleExecutor";
 import { logger } from "../logger";
+import { crash } from "../utils/errors";
 
 export async function executeTs(filePath: string, options: any): Promise<void> {
   const customModuleHandler = (module: any, filename: string) => {

--- a/packages/client/src/file-handling/settings.ts
+++ b/packages/client/src/file-handling/settings.ts
@@ -4,6 +4,7 @@ import { existsSync } from "fs";
 import { loadJson } from "../file-executors/executeJson";
 import { loadYaml } from "../file-executors/executeYaml";
 import { DeepPartial } from "ts-essentials";
+import { crash } from "../utils/errors";
 
 const CODECHECKS_SETTINGS_FILES_NAMES = ["codechecks.yml", "codechecks.yaml", "codechecks.json"];
 

--- a/packages/client/src/file-handling/settings.ts
+++ b/packages/client/src/file-handling/settings.ts
@@ -32,7 +32,7 @@ function loadSettingsFromFile(filePath: string): CodeChecksSettings | undefined 
     case "yaml":
       return (loadYaml(filePath) || {}).settings;
     default:
-      throw new Error(`Unsupported file extension ${extension}`);
+      throw crash(`Unsupported file extension ${extension}`);
   }
 }
 

--- a/packages/client/src/getExecutionContext.ts
+++ b/packages/client/src/getExecutionContext.ts
@@ -22,7 +22,7 @@ export async function getConstExecutionContext(
   const pr = await ciProvider.getPullRequestID();
   const projectSlug = await ciProvider.getProjectSlug();
   if (!pr && isFork) {
-    throw new Error("Provider should never be in fork mode and not in PR mode!");
+    throw crash("Provider should never be in fork mode and not in PR mode!");
   }
 
   let prInfo: PrInfo | undefined;

--- a/packages/client/src/getExecutionContext.ts
+++ b/packages/client/src/getExecutionContext.ts
@@ -6,6 +6,7 @@ import { dirname } from "path";
 import { LocalProvider } from "./ci-providers/Local";
 import { CodeChecksSettings, CodeChecksClientArgs } from "./types";
 import { getPrInfoForSpeculativeBranch } from "./speculativeBranchSelection";
+import { crash } from "./utils/errors";
 
 /**
  * Better part of execution context stays the same for all codechecks files being executed so we just get it once.

--- a/packages/client/src/runner.ts
+++ b/packages/client/src/runner.ts
@@ -17,7 +17,7 @@ import { checkIfIsLocalMode } from "./ci-providers/Local";
 import { logger, printLogo, bold, formatSHA, formatPath } from "./logger";
 import { loadCodechecksSettings } from "./file-handling/settings";
 import { findRootGitRepository } from "./utils/git";
-import { crash, isCodeChecksCrashError } from "./utils/errors";
+import { crash, isCodeChecksCrash } from "./utils/errors";
 import { CodeChecksClientArgs } from "./types";
 
 async function main(
@@ -90,7 +90,7 @@ const args: CodeChecksClientArgs = {
 
 main(args, command.args.length > 0 ? command.args.map(a => normalizePath(a)) : undefined).catch(e => {
   // we want informative output but we don't want leaking secrets into any logs
-  if (isCodeChecksCrashError(e)) {
+  if (isCodeChecksCrash(e)) {
     logger.error(maskSecrets(e.message, process.env));
     logger.debug(maskSecrets(inspect(e), process.env));
   } else {

--- a/packages/client/src/runner.ts
+++ b/packages/client/src/runner.ts
@@ -17,6 +17,7 @@ import { checkIfIsLocalMode } from "./ci-providers/Local";
 import { logger, printLogo, bold, formatSHA, formatPath } from "./logger";
 import { loadCodechecksSettings } from "./file-handling/settings";
 import { findRootGitRepository } from "./utils/git";
+import { crash, isCodeChecksCrashError } from "./utils/errors";
 import { CodeChecksClientArgs } from "./types";
 
 async function main(
@@ -37,7 +38,7 @@ async function main(
 
   const gitRoot = findRootGitRepository(process.cwd());
   if (!gitRoot) {
-    throw new Error("Couldn't find git project root!");
+    throw crash("Couldn't find git project root!");
   }
   const settings = await loadCodechecksSettings(gitRoot);
   const sharedExecutionCtx = await getConstExecutionContext(api, provider, settings, gitRoot, args);
@@ -89,8 +90,12 @@ const args: CodeChecksClientArgs = {
 
 main(args, command.args.length > 0 ? command.args.map(a => normalizePath(a)) : undefined).catch(e => {
   // we want informative output but we don't want leaking secrets into any logs
-  logger.error(maskSecrets(e.message, process.env));
-  logger.debug(maskSecrets(inspect(e), process.env));
+  if (isCodeChecksCrashError(e)) {
+    logger.error(maskSecrets(e.message, process.env));
+    logger.debug(maskSecrets(inspect(e), process.env));
+  } else {
+    logger.log(maskSecrets(inspect(e), process.env));
+  }
   process.exit(1);
 });
 

--- a/packages/client/src/speculativeBranchSelection.ts
+++ b/packages/client/src/speculativeBranchSelection.ts
@@ -16,7 +16,7 @@ export async function getPrInfoForSpeculativeBranch(
     return;
   }
   if (baseCommit === headCommit) {
-    throw new Error(
+    throw crash(
       `Speculative branch selection failed. baseCommit can't be equal to headCommit (${baseCommit}). Please create Pull Request to skip this problem.`,
     );
   }

--- a/packages/client/src/speculativeBranchSelection.ts
+++ b/packages/client/src/speculativeBranchSelection.ts
@@ -1,6 +1,7 @@
 import { PrInfo, FileStatuses } from "./api";
 import { CodeChecksSettings } from "./types";
 import { logger } from "./logger";
+import { crash } from "./utils/errors";
 import execa = require("execa");
 
 const diffParser = require("./js/diff-parser/diff-parser.js").DiffParser;

--- a/packages/client/src/utils.ts
+++ b/packages/client/src/utils.ts
@@ -1,5 +1,6 @@
 import { Opaque, Dictionary } from "ts-essentials";
 import { resolve, isAbsolute } from "path";
+import { crash } from "./utils/errors";
 
 export function runOrCatchError<T>(fn: () => T): T | undefined {
   try {

--- a/packages/client/src/utils.ts
+++ b/packages/client/src/utils.ts
@@ -12,7 +12,7 @@ export function runOrCatchError<T>(fn: () => T): T | undefined {
 export function getRequiredEnv(name: string): string {
   const value = process.env[name];
   if (value === undefined) {
-    throw new Error(`Required env var ${name} missing`);
+    throw crash(`Required env var ${name} missing`);
   }
 
   return value;
@@ -35,6 +35,6 @@ export function maskSecrets(output: string, env: Dictionary<string | undefined>)
 
 export function ensureAbsolutePath(path: string): void {
   if (!isAbsolute(path)) {
-    throw new Error(`${path} has to be an absolute path!`);
+    throw crash(`${path} has to be an absolute path!`);
   }
 }

--- a/packages/client/src/utils/errors.ts
+++ b/packages/client/src/utils/errors.ts
@@ -1,0 +1,9 @@
+class CodeChecksCrashError extends Error {}
+
+export function crash(message: string): never {
+  throw new CodeChecksCrashError(message);
+}
+
+export function isCodeChecksCrash(error: CodeChecksCrashError): error is CodeChecksCrashError {
+  return error instanceof CodeChecksCrashError;
+}

--- a/packages/client/src/utils/git.ts
+++ b/packages/client/src/utils/git.ts
@@ -1,5 +1,6 @@
 import { existsSync } from "fs";
 import { join } from "path";
+import { crash } from "./errors";
 
 const REMOTE_URL_REGEXP = /^(?:(?:git\@)|(?:https?:\/\/))github\.com(?::|\/)(.+)$/;
 

--- a/packages/client/src/utils/git.ts
+++ b/packages/client/src/utils/git.ts
@@ -21,7 +21,7 @@ export function findRootGitRepository(path: string): string | undefined {
 export function fullNameFromRemoteUrl(remoteUrl: string): string {
   const matches = remoteUrl.match(REMOTE_URL_REGEXP);
   if (!matches || !matches[1]) {
-    throw new Error(`Can't get project slug from ${remoteUrl}`);
+    throw crash(`Can't get project slug from ${remoteUrl}`);
   }
   return matches[1].replace(/(.git)$/, "");
 }


### PR DESCRIPTION
This aims to fix #32. Errors we have in the client are some sort of assertions throughout the code.

> In a high-quality code base it might still be OK to crash upon encountering an error that we don’t care to handle, but we’d want to do it using a separate mechanism. Jesse mentions that Mozilla has a MOZ_CRASH(message) construct that serves this purpose.
>
> source: https://blog.regehr.org/archives/1091

The implementation is loosely inspired by MOZ_CRASH. Due to TypeScript type inference limitations, we have to use `if` and `throw` - I don't think it can't be replaced by just `crash(condition, "message")`. 

How known crash is handled

```
Executing 1 codechecks files
Error occured:  Couldn't find git project root!
```

How unknown error is handled

```
Executing 1 codechecks files
Error: Couldn't find git project root!
    at main (/Users/user/monorepo/packages/client/dist/runner.js:33:15)
    at Object.<anonymous> (/Users/user/monorepo/packages/client/dist/runner.js:74:1)
    at Module._compile (internal/modules/cjs/loader.js:689:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)
    at Module.load (internal/modules/cjs/loader.js:599:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:538:12)
    at Function.Module._load (internal/modules/cjs/loader.js:530:3)
    at Function.Module.runMain (internal/modules/cjs/loader.js:742:12)
```
