### PR TITLE
Add typescript to client to satisfy node-ts peer dep

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -44,6 +44,7 @@
     "request-promise": "^4.2.2",
     "ts-essentials": "^1.0.2",
     "ts-node": "^8.0.2",
+    "typescript": ">=2.7.0",
     "url-join": "^4.0.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6795,6 +6795,11 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
+typescript@>=2.7.0:
+  version "3.7.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.4.tgz#1743a5ec5fef6a1fa9f3e4708e33c81c73876c19"
+  integrity sha512-A25xv5XCtarLwXpcDNZzCGvW2D1S3/bACratYBx2sax8PefsFhlYmkQicKHvpYflFS8if4zne5zT5kpJ7pzuvw==
+
 typescript@^3.1.6:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.2.2.tgz#fe8101c46aa123f8353523ebdcf5730c2ae493e5"


### PR DESCRIPTION
This fixes #70 by adding a dependency that will pull in typescript, which
node-ts demands as a peer dependency but can't install itself.

The version comes from what `node-ts` currently requires.