### PR TITLE
feat: Support patterns for speculative branch execution [WIP]

### DIFF
--- a/packages/client/src/speculativeBranchSelection.test.ts
+++ b/packages/client/src/speculativeBranchSelection.test.ts
@@ -1,0 +1,23 @@
+import { findSpeculativeBaseBranch } from "./speculativeBranchSelection";
+
+describe("speculativeBranchSelection", () => {
+  describe("findSpeculativeBaseBranch", () => {
+    it("should return first matching branch", () => {
+      const branches = ["master", "develop", "foobar"];
+
+      expect(findSpeculativeBaseBranch("develop", branches)).toBe("develop");
+    });
+
+    it("should support matching branch with glob pattern", () => {
+      const branches = ["master", "v*-maintenance"];
+
+      expect(findSpeculativeBaseBranch("v1-maintenance", branches)).toBe("v1-maintenance");
+    });
+
+    it("should return first configured branch by default", () => {
+      const branches = ["master", "develop"];
+
+      expect(findSpeculativeBaseBranch("someBranch", branches)).toBe("master");
+    });
+  });
+});


### PR DESCRIPTION
Closes https://github.com/codechecks/monorepo/issues/77

Let me know if there are any concerns around this. I focused on one function to keep changes minimal and used existing the `minimatch` instance exposed from `glob` to avoid introducing additional dependencies, but there are other possibilities if that's desired.

❓ Open question below.